### PR TITLE
Add fiona to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ geopandas
 shapely
 matplotlib
 descartes
+fiona


### PR DESCRIPTION
This fixes the `ModuleNotFoundError: No module named 'fiona'` fatal error on startup that was introduced with commit 358382d.